### PR TITLE
Refactor (src/controllers/write/categories.js): reduce code duplication between `Categories.follow` and `Categories.unfollow`

### DIFF
--- a/src/controllers/write/categories.js
+++ b/src/controllers/write/categories.js
@@ -106,7 +106,7 @@ Categories.setModerator = async (req, res) => {
 	helpers.formatApiResponse(200, res, privilegeSet);
 };
 
-Categories.follow = async (req, res, next) => {
+const handleFollow = action => async (req, res, next) => {
 	const { actor } = req.body;
 	const id = parseInt(req.params.cid, 10);
 
@@ -114,28 +114,13 @@ Categories.follow = async (req, res, next) => {
 		return next();
 	}
 
-	await api.activitypub.follow(req, {
-		type: 'cid',
-		id,
-		actor,
-	});
+	const params = { type: 'cid', id, actor };
+	const fn = action === 'follow' ? api.activitypub.follow : api.activitypub.unfollow;
+	await fn(req, params);
 
 	helpers.formatApiResponse(200, res, {});
 };
 
-Categories.unfollow = async (req, res, next) => {
-	const { actor } = req.body;
-	const id = parseInt(req.params.cid, 10);
+Categories.follow = handleFollow('follow');
 
-	if (!id) { // disallow cid 0
-		return next();
-	}
-
-	await api.activitypub.unfollow(req, {
-		type: 'cid',
-		id,
-		actor,
-	});
-
-	helpers.formatApiResponse(200, res, {});
-};
+Categories.unfollow = handleFollow('unfollow');

--- a/src/controllers/write/categories.js
+++ b/src/controllers/write/categories.js
@@ -106,7 +106,7 @@ Categories.setModerator = async (req, res) => {
 	helpers.formatApiResponse(200, res, privilegeSet);
 };
 
-const handleFollow = action => async (req, res, next) => {
+Categories.follow = async (req, res, next) => {
 	const { actor } = req.body;
 	const id = parseInt(req.params.cid, 10);
 
@@ -114,13 +114,28 @@ const handleFollow = action => async (req, res, next) => {
 		return next();
 	}
 
-	const params = { type: 'cid', id, actor };
-	const fn = action === 'follow' ? api.activitypub.follow : api.activitypub.unfollow;
-	await fn(req, params);
+	await api.activitypub.follow(req, {
+		type: 'cid',
+		id,
+		actor,
+	});
 
 	helpers.formatApiResponse(200, res, {});
 };
 
-Categories.follow = handleFollow('follow');
+Categories.unfollow = async (req, res, next) => {
+	const { actor } = req.body;
+	const id = parseInt(req.params.cid, 10);
 
-Categories.unfollow = handleFollow('unfollow');
+	if (!id) { // disallow cid 0
+		return next();
+	}
+
+	await api.activitypub.unfollow(req, {
+		type: 'cid',
+		id,
+		actor,
+	});
+
+	helpers.formatApiResponse(200, res, {});
+};


### PR DESCRIPTION
# P1B: Starter Task: Refactoring PR

**Use this pull request template to briefly answer the questions below in one to two sentences each.**
Feel free to delete this text at the top after filling out the template.

> You are **not permitted** to use generative AI services (e.g., ChatGPT) to compose the answers.
> Any such use will be treated as a violation of academic integrity.

## 1. Issue

**Please provide a link to the associated GitHub issue:** #3 

**Link to the associated GitHub issue:** #3 

**Full path to the refactored file:** `src/controllers/write/categories.js`

**What do you think this file does?**
*(Your answer does not have to be 100% correct; give a reasonable, evidence‑based guess.)*
This file implements methods to follow/unfollow a "Group Actor" via the ActivityPub protocol.

**What is the scope of your refactoring within that file?**
*(Name specific functions/blocks/regions touched.)*
`Categories.follow` and `Categories.unfollow` methods. I changed them to wrap around a `handleFollow` helper that executes nearly the same code for both calls.

**Which Qlty‑reported issue did you address?**
*(Name the rule/metric and include the BEFORE value; e.g., “Cognitive Complexity 18 in render()”.)*
Original issue: Found 16 lines of similar code in 2 locations (mass = 66). This was between `Categories.follow` and `Categories.unfollow`.
**Why I addressed it:** the code between the two methods was nearly identical. Having them wrap around a helper means less maintenance cost when modifying similar follow/unfollow logic.

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s adaptability?**
The follow and unfollow methods were nearly identical. They only differed by one line, which contained the ActivityPub follow/unfollow API call. If a developer were to build on top of the existing `Categories.follow` and `Categories.unfollow` methods, they would have to modify two locations in the code, which can lead to increase in maintainability cost.

**What changes did you make to resolve the issue?**
I created a `handleFollow` helper function that closes over an `action` string to determine whether the category follow action was a follow/unfollow. The old `Category.follow` and `Category.unfollow` methods wrap around `handleFollow`, which is a higher-order function. The helper function then waits for `api.activitypub.follow` or `api.activitypub.unfollow` to finish before sending a 200 response like before.

**How do your changes improve adaptability? Did you consider alternatives?**
It improves adaptabilitiy by reducing the duplicated follow/unfollow logic and therefore reducing the amount of code for a developer to read/modify. Additionally, if further changes are made to the follow/unfollow methods, developers (hopefully) would only have to modify the `handleFollow` helper instead of the two methods.

An alternative I explored was using a map for actions inside a single handler (e.g. `executeFollowAction(req, res, next, 'follow' | 'unfollow')` and two thin wrappers that call it. However, qlty smell would report too many parameters coming from `executeFollowAction`. Therefore it made more sense to use a higher-order function, `handleFollow`, that close over an action (follow/unfollow) as 1 parameter to generate two async Express handlers (they return `req`, `res`, `next`).

## 3. Validation

**How did you trigger the refactored code path from the UI?**
I triggered the refactored code path from the UI by:

Clicking on Admin (under Categories in left-hand side) > Manage > Categories > Announcements (could be any category) > Federation > typing URL of application that uses ActivityPub protocol for following/unfollowing content (e.g. I used https://lemmy.world/c/programming) > clicking 'Follow'.

I could also trigger the refactored code path by unfollowing (by clicking 'Unfollow') right after.

**Attach a screenshot of the logs and UI demonstrating the trigger.**
*(Run `./nodebb log`; include the relevant UI view. Temporary logs should be removed before final commit.)*

Evidence of log being triggered after interacting with UI:
<img width="2100" height="1670" alt="image" src="https://github.com/user-attachments/assets/aabcaa77-440c-4ca7-84a9-1ed6eba8bfb8" />

ActivityPub category follow/unfollow UI where logs were triggered:
<img width="1580" height="1092" alt="image" src="https://github.com/user-attachments/assets/5934553e-d94e-410e-a9b7-c7e488b21472" />
<img width="1696" height="1216" alt="image" src="https://github.com/user-attachments/assets/ae4b9d9f-4df8-4dfa-a53f-42723c404eab" />


**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**
<img width="2150" height="270" alt="image" src="https://github.com/user-attachments/assets/76309399-8c05-4543-ae54-e93fce081518" />

