### PR TITLE
Added reaction emojis to front-end display

### DIFF
--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/post.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/post.tpl
@@ -118,6 +118,18 @@
 
 					{{{ if !reputation:disabled }}}
 					<div class="d-flex votes align-items-center">
+						<span class="btn btn-ghost btn-sm">
+							<i class="fa fa-thumbs-up text-warning"></i>
+						</span>
+
+						<span class="btn btn-ghost btn-sm">
+							<i class="fa fa-heart text-danger"></i>
+						</span>
+
+						<span class="btn btn-ghost btn-sm">
+							<i class="fa fa-smile-o"></i>
+						</span>
+
 						<a component="post/upvote" href="#" class="btn btn-ghost btn-sm{{{ if posts.upvoted }}} upvoted{{{ end }}}" title="[[topic:upvote-post]]">
 							<i class="fa fa-fw fa-chevron-up text-primary"></i>
 						</a>


### PR DESCRIPTION
## 1. Issue

Resolves: https://github.com/CMU-313/nodebb-fall-2025-blind-hikers/issues/14

Modified: templates/partials/topic/post.tpl

The file defines how a post is rendered and displayed inside a topic thread. Each post includes user info, content, reactions, replies, and other actions. 

## 2. Feature Added

We decided to add three emoji reactions: thumbs up, heart, and smiley face. The three icons were added to the same footer bar that already contains other actions that users can take on a post. The icons come from the same library that other NodeBB icons are from (FontAwesome) to maintain consistency with style and design.

## 3. Validation

Reactions icons are visibly displayed on the website, next to the existing quotation and upvote icons.
<img width="2440" height="962" alt="SCR 20250921 153607@2x" src="https://github.com/user-attachments/assets/3491785a-7b4b-478d-87b6-4bd2ce12ddfa" />

