### PR TITLE
Added emoji hover functionality

### DIFF
--- a/public/scss/reactions.scss
+++ b/public/scss/reactions.scss
@@ -17,6 +17,12 @@
 	gap: 0.25rem;
 	min-width: auto;
 	
+	.emoji-reaction {
+		font-size: 1.2rem;
+		line-height: 1;
+		transition: all 0.2s ease;
+	}
+	
 	&.reacted {
 		background-color: #f8f9fa;
 		border-color: var(--bs-border-color);
@@ -30,6 +36,10 @@
 			color: var(--bs-secondary);
 			font-weight: 700;
 		}
+		
+		.emoji-reaction {
+			transform: scale(1.1);
+		}
 	}
 	
 	&:hover {
@@ -41,6 +51,11 @@
 		
 		.reaction-count {
 			transform: scale(1.1);
+		}
+		
+		.emoji-reaction {
+			transform: scale(1.15);
+			filter: brightness(1.2);
 		}
 	}
 }

--- a/public/scss/reactions.scss
+++ b/public/scss/reactions.scss
@@ -64,9 +64,46 @@
 .votes {
 	[component="post/reaction"] {
 		margin-right: 0.25rem;
+		position: relative;
 		
 		&:last-child {
 			margin-right: 0;
 		}
+	}
+}
+
+// Custom tooltip for emoji reactions
+.emoji-tooltip {
+	position: absolute;
+	bottom: 100%;
+	left: 50%;
+	transform: translateX(-50%);
+	background-color: rgba(0, 0, 0, 0.8);
+	color: white;
+	padding: 0.25rem 0.5rem;
+	border-radius: 0.25rem;
+	font-size: 0.75rem;
+	font-weight: 500;
+	white-space: nowrap;
+	z-index: 1000;
+	opacity: 0;
+	visibility: hidden;
+	transition: all 0.2s ease;
+	pointer-events: none;
+	margin-bottom: 0.25rem;
+	
+	&::after {
+		content: '';
+		position: absolute;
+		top: 100%;
+		left: 50%;
+		transform: translateX(-50%);
+		border: 4px solid transparent;
+		border-top-color: rgba(0, 0, 0, 0.8);
+	}
+	
+	&.show {
+		opacity: 1;
+		visibility: visible;
 	}
 }

--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -7,6 +7,7 @@ define('forum/topic', [
 	'forum/topic/postTools',
 	'forum/topic/events',
 	'forum/topic/posts',
+	'forum/topic/emojiTooltips',
 	'navigator',
 	'sort',
 	'quickreply',
@@ -19,7 +20,7 @@ define('forum/topic', [
 	'clipboard',
 ], function (
 	infinitescroll, threadTools, postTools,
-	events, posts, navigator, sort, quickreply,
+	events, posts, emojiTooltips, navigator, sort, quickreply,
 	components, storage, hooks, api, alerts,
 	bootbox, clipboard
 ) {
@@ -54,6 +55,7 @@ define('forum/topic', [
 		postTools.init(tid);
 		threadTools.init(tid, $('.topic'));
 		events.init();
+		emojiTooltips.init();
 
 		sort.handleSort('topicPostSort', 'topic/' + ajaxify.data.slug);
 

--- a/public/src/client/topic/emojiTooltips.js
+++ b/public/src/client/topic/emojiTooltips.js
@@ -1,0 +1,42 @@
+'use strict';
+
+define('forum/topic/emojiTooltips', [], function () {
+	const EmojiTooltips = {};
+
+	EmojiTooltips.init = function () {
+		// Remove any existing tooltip handlers
+		EmojiTooltips.destroy();
+		
+		// Add tooltip functionality to all reaction buttons
+		$('[component="post/reaction"][data-tooltip]').each(function () {
+			const $button = $(this);
+			const tooltipText = $button.attr('data-tooltip');
+			
+			// Create tooltip element
+			const $tooltip = $('<div class="emoji-tooltip">' + tooltipText + '</div>');
+			$button.append($tooltip);
+			
+			// Add hover events
+			$button.on('mouseenter.emojiTooltip', function () {
+				$tooltip.addClass('show');
+			});
+			
+			$button.on('mouseleave.emojiTooltip', function () {
+				$tooltip.removeClass('show');
+			});
+		});
+	};
+
+	EmojiTooltips.destroy = function () {
+		// Remove all tooltip event handlers and elements
+		$('[component="post/reaction"]').off('.emojiTooltip');
+		$('.emoji-tooltip').remove();
+	};
+
+	EmojiTooltips.refresh = function () {
+		// Re-initialize tooltips (useful after dynamic content changes)
+		EmojiTooltips.init();
+	};
+
+	return EmojiTooltips;
+});

--- a/public/src/client/topic/posts.js
+++ b/public/src/client/topic/posts.js
@@ -412,6 +412,11 @@ define('forum/topic/posts', [
 	Posts.onNewPostsAddedToDom = async function (posts) {
 		await Posts.onTopicPageLoad(posts);
 		posts.find('.timeago').timeago();
+		
+		// Refresh emoji tooltips for new posts
+		require(['forum/topic/emojiTooltips'], function (emojiTooltips) {
+			emojiTooltips.refresh();
+		});
 	};
 
 	Posts.showBottomPostBar = function () {

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/post.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/post.tpl
@@ -118,17 +118,17 @@
 
 					{{{ if !reputation:disabled }}}
 					<div class="d-flex votes align-items-center">
-						<span class="btn btn-ghost btn-sm{{{ if posts.reactions.thumbs-up.hasReacted }}} reacted{{{ end }}}" component="post/reaction" data-reaction="thumbs-up" title="👍 :thumbs-up:">
+						<span class="btn btn-ghost btn-sm{{{ if posts.reactions.thumbs-up.hasReacted }}} reacted{{{ end }}}" component="post/reaction" data-reaction="thumbs-up" data-tooltip=":thumbs-up:">
 							<span class="emoji-reaction">👍</span>
 							<span class="reaction-count ms-1{{{ if !posts.reactions.thumbs-up.count }}} hidden{{{ end }}}" component="post/reaction-count" data-reaction="thumbs-up">{posts.reactions.thumbs-up.count}</span>
 						</span>
 
-						<span class="btn btn-ghost btn-sm{{{ if posts.reactions.heart.hasReacted }}} reacted{{{ end }}}" component="post/reaction" data-reaction="heart" title="❤️ :heart:">
+						<span class="btn btn-ghost btn-sm{{{ if posts.reactions.heart.hasReacted }}} reacted{{{ end }}}" component="post/reaction" data-reaction="heart" data-tooltip=":heart:">
 							<span class="emoji-reaction">❤️</span>
 							<span class="reaction-count ms-1{{{ if !posts.reactions.heart.count }}} hidden{{{ end }}}" component="post/reaction-count" data-reaction="heart">{posts.reactions.heart.count}</span>
 						</span>
 
-						<span class="btn btn-ghost btn-sm{{{ if posts.reactions.smile.hasReacted }}} reacted{{{ end }}}" component="post/reaction" data-reaction="smile" title="😊 :smile:">
+						<span class="btn btn-ghost btn-sm{{{ if posts.reactions.smile.hasReacted }}} reacted{{{ end }}}" component="post/reaction" data-reaction="smile" data-tooltip=":smile:">
 							<span class="emoji-reaction">😊</span>
 							<span class="reaction-count ms-1{{{ if !posts.reactions.smile.count }}} hidden{{{ end }}}" component="post/reaction-count" data-reaction="smile">{posts.reactions.smile.count}</span>
 						</span>

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/post.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/post.tpl
@@ -118,18 +118,18 @@
 
 					{{{ if !reputation:disabled }}}
 					<div class="d-flex votes align-items-center">
-						<span class="btn btn-ghost btn-sm{{{ if posts.reactions.thumbs-up.hasReacted }}} reacted{{{ end }}}" component="post/reaction" data-reaction="thumbs-up">
-							<i class="fa fa-thumbs-up text-warning"></i>
+						<span class="btn btn-ghost btn-sm{{{ if posts.reactions.thumbs-up.hasReacted }}} reacted{{{ end }}}" component="post/reaction" data-reaction="thumbs-up" title="👍 :thumbs-up:">
+							<span class="emoji-reaction">👍</span>
 							<span class="reaction-count ms-1{{{ if !posts.reactions.thumbs-up.count }}} hidden{{{ end }}}" component="post/reaction-count" data-reaction="thumbs-up">{posts.reactions.thumbs-up.count}</span>
 						</span>
 
-						<span class="btn btn-ghost btn-sm{{{ if posts.reactions.heart.hasReacted }}} reacted{{{ end }}}" component="post/reaction" data-reaction="heart">
-							<i class="fa fa-heart text-danger"></i>
+						<span class="btn btn-ghost btn-sm{{{ if posts.reactions.heart.hasReacted }}} reacted{{{ end }}}" component="post/reaction" data-reaction="heart" title="❤️ :heart:">
+							<span class="emoji-reaction">❤️</span>
 							<span class="reaction-count ms-1{{{ if !posts.reactions.heart.count }}} hidden{{{ end }}}" component="post/reaction-count" data-reaction="heart">{posts.reactions.heart.count}</span>
 						</span>
 
-						<span class="btn btn-ghost btn-sm{{{ if posts.reactions.smile.hasReacted }}} reacted{{{ end }}}" component="post/reaction" data-reaction="smile">
-							<i class="fa fa-smile-o"></i>
+						<span class="btn btn-ghost btn-sm{{{ if posts.reactions.smile.hasReacted }}} reacted{{{ end }}}" component="post/reaction" data-reaction="smile" title="😊 :smile:">
+							<span class="emoji-reaction">😊</span>
 							<span class="reaction-count ms-1{{{ if !posts.reactions.smile.count }}} hidden{{{ end }}}" component="post/reaction-count" data-reaction="smile">{posts.reactions.smile.count}</span>
 						</span>
 


### PR DESCRIPTION
## 1. Issue

Resolves: https://github.com/CMU-313/nodebb-fall-2025-blind-hikers/issues/15

Modified:
`public/scss/reactions.scss` - Added CSS styling for emoji reactions with hover effects and custom tooltip positioning.
`public/src/client/topic.js` - Imported the emoji tooltips module and initialized it when topics load.
`public/src/client/topic/emojiTooltips.js` - Created a new JavaScript file that handles showing/hiding tooltips when you hover over reaction buttons.
`public/src/client/topic/posts.js` - Added code to refresh tooltips when new posts are loaded so they work dynamically.
`vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/post.tpl` - Replaced FontAwesome icons with actual emojis (👍❤️😊) and added data attributes for tooltips.

## 2. Feature Added

Added a feature that displays the emoji name when a user hovers over the emoji icon. It displays both when you've reacted and when you haven't for all posts and replies. Additionally, the three icons were changed to emoji icons to maintain consistency with the emoji names displayed.

## 3. Validation

Emoji icons are visibly displayed on the website, and when the user hovers over the emoji, the emoji name appears above the emoji.

Without reactions:
<img width="1444" height="736" alt="Screenshot 2025-10-03 at 7 17 26 PM" src="https://github.com/user-attachments/assets/106de01c-d689-4782-ac27-10ad76c6949b" />

With reactions:
<img width="1484" height="746" alt="Screenshot 2025-10-03 at 7 17 14 PM" src="https://github.com/user-attachments/assets/da2f0d86-5892-44c9-82a1-7a1a9dec7e99" />
