### PR TITLE
Integrated microservice into NodeBB

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,9 @@ services:
     build: .
     # image: ghcr.io/nodebb/nodebb:latest
     restart: unless-stopped
+    depends_on:
+      translator:
+        condition: service_started
     ports:
       - '4567:4567' # comment this out if you don't want to expose NodeBB to the host, or change the first number to any port you want
     volumes:
@@ -11,6 +14,8 @@ services:
       - nodebb-uploads:/usr/src/app/public/uploads
       - nodebb-config:/opt/config
       - ./install/docker/setup.json:/usr/src/app/setup.json
+    environment:
+      - TRANSLATOR_SERVICE_URL=http://translator:8080
 
   mongo:
     image: 'mongo:7-jammy'
@@ -45,6 +50,17 @@ services:
       - postgres-data:/var/lib/postgresql/data
     profiles:
       - postgres
+
+  translator:
+    build:
+      context: https://github.com/CMU-313/llm-experiment-microservice-blind-hikers.git#f25
+    restart: unless-stopped
+    environment:
+      - PORT=8080
+      # Point this at your running Ollama instance; adjust or remove if using a remote LLM.
+      - OLLAMA_HOST=http://ollama:11434
+    ports:
+      - '8080:8080'
 
 volumes:
   mongo-data:


### PR DESCRIPTION
## Description

- Updated the NodeBB translator client to post JSON to the microservice’s `/translate/` endpoint
- Documented the translator service URL in `docker-compose.yml`, defaulting to the host mapping used for local development

## Testing

- Manually ran `curl -X POST http://host.docker.internal:5000/translate/` with sample Spanish text and confirmed `{"is_english":false,"translated_content":"Hello"}` response
- Created a new non-English forum post and verified the translated-content toggle renders once the microservice responds
- Note that it took around 30 seconds for the new post to be visible with the button, but the button works once posted

## Files Changed

- `src/translate/index.js`
- `docker-compose.yml`

## Screenshots

<img width="408" height="172" alt="PNG image" src="https://github.com/user-attachments/assets/6cea999a-5042-489f-800a-8b01871d56e4" />

Here is an image showing the button appearing with the translated text below.